### PR TITLE
Interpret the MODS element "digitalOrigin"

### DIFF
--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -27,6 +27,7 @@ class Mets:
         self.places = None
         self.dates = None
         self.publishers = None
+        self.digital_origin = None
 
     @classmethod
     def read(cls, source):
@@ -110,10 +111,16 @@ class Mets:
             self.dates.append(date_ext)
 
         #
-        # publication dates
+        # publishers
         self.publishers = []
         for publisher in self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:originInfo[1]/mods:publisher", namespaces=ns):
             self.publishers.append(publisher.text)
+
+        #
+        # digital_origin
+        for digital_origin in self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:physicalDescription[1]/mods:digitalOrigin", namespaces=ns):
+            self.digital_origin = digital_origin.text
+            break
 
 
     def get_main_title(self):
@@ -151,3 +158,15 @@ class Mets:
         Return the publishers
         """
         return self.publishers
+
+    def has_digital_origin(self):
+        """
+        Element "digitalOrigin" present?
+        """
+        return self.digital_origin != None
+
+    def get_digital_origin(self):
+        """
+        Return the digital origin
+        """
+        return self.digital_origin

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -103,3 +103,12 @@ class Tei:
         name = etree.SubElement(publisher_node, "name")
         name.text = publisher
         publication_stmt.insert(0, publisher_node)
+
+    def add_digital_edition(self, digital_edition):
+        """
+        Adds an edition statement with details on the digital edition.
+        """
+        title_stmt = self.tree.xpath('//tei:titleStmt', namespaces=ns)[0]
+        edition_stmt = etree.SubElement(title_stmt, "editionStmt")
+        edition = etree.SubElement(edition_stmt, "edition")
+        edition.text = digital_edition

--- a/mets_mods2teiHeader/data/tei_skeleton.xml
+++ b/mets_mods2teiHeader/data/tei_skeleton.xml
@@ -11,7 +11,6 @@
           </resp>
         </respStmt>
       </titleStmt>
-      <editionStmt><edition>Vollständige digitalisierte Ausgabe.</edition></editionStmt>
       <extent>
         <measure type="images">[Umfang in Bilddateien]</measure>
         <measure type="tokens">[Umfang in Tokens]</measure>

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -56,6 +56,10 @@ def cli(mets):
     for publisher in mets.get_publishers():
         tei.add_publisher(publisher)
 
+    # digital edition
+    if mets.has_digital_origin():
+        tei.add_digital_edition(mets.get_digital_origin())
+
     click.echo(tei.tostring())
 
 


### PR DESCRIPTION
This an optional element describing the source of a digital file.
Its most appropriate equivalent in the TEI header is the edition
statement.