### PR TITLE
Add the TEI skeleton to the installed files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email='kay-michael.wuerzner@slub-dresden.de',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
+    package_data={'mets_mods2teiHeader' : ['data/tei_skeleton.xml']},
     install_requires=[
     ],
     entry_points={


### PR DESCRIPTION
It was not installed before but is now via `package_data`.

Fixes https://github.com/wrznr/mets-mods2teiHeader/issues/11