### PR TITLE
Add contents to the encoding description

### DIFF
--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -32,6 +32,8 @@ class Mets:
         self.owner_digital = None
         self.license = None
         self.license_url = None
+        self.encoding_date = None
+        self.encoding_desc = None
 
     @classmethod
     def read(cls, source):
@@ -143,10 +145,18 @@ class Mets:
             license_nodes = self.tree.xpath("////mets:dmdSec[1]//mods:mods/mods:accessCondition[@type='use and reproduction']", namespaces=ns)
             if license_nodes != []:
                 self.license = license_nodes[0].text
-                self.license_url = license_nodes[0].get("href", "")
+                self.license_url = license_nodes[0].get(XLINK + "href", "")
             else:
                 self.license = ""
                 self.license_url = ""
+
+        #
+        # data encoding
+        header_node = self.tree.xpath("//mets:metsHdr", namespaces=ns)[0]
+        self.encoding_date = header_node.get("CREATEDATE")
+        for agent in header_node.xpath("//mets:agent", namespaces=ns):
+            if agent.get("OTHERTYPE") == "SOFTWARE":
+                self.encoding_desc = agent.xpath("//mets:name", namespaces=ns)[0].text
 
 
     def get_main_title(self):
@@ -214,3 +224,15 @@ class Mets:
         Return the url of the license of the digital edition
         """
         return self.license_url
+
+    def get_encoding_date(self):
+        """
+        Return the date of encoding for the digital edition
+        """
+        return self.encoding_date
+
+    def get_encoding_description(self):
+        """
+        Return details on the encoding of the digital edition
+        """
+        return self.encoding_desc

--- a/mets_mods2teiHeader/data/tei_skeleton.xml
+++ b/mets_mods2teiHeader/data/tei_skeleton.xml
@@ -14,12 +14,6 @@
         <biblFull>
           <titleStmt>
             <title level="m" type="main">[Haupttitel einer Monographie]</title>
-            <author>
-              <persName ref="http://d-nb.info/gnd/XXX">
-                <surname>[Familienname des Autors]</surname>
-                <forename>[Vorname des Autors]</forename>
-              </persName>
-            </author>
           </titleStmt>
           <editionStmt>
             <edition n="1"/>
@@ -45,7 +39,6 @@
       </sourceDesc>
     </fileDesc>
     <encodingDesc>
-      <p>[Hinweise zu den Transkriptions- und Annotationsrichtlinien]</p>
     </encodingDesc>
     <profileDesc>
       <langUsage>

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -69,6 +69,10 @@ def cli(mets):
     else:
         tei.set_availability("restricted", mets.get_license(), mets.get_license_url())
 
+    # encoding
+    tei.set_encoding_date(mets.get_encoding_date())
+    tei.set_encoding_description(mets.get_encoding_description())
+
     click.echo(tei.tostring())
 
 


### PR DESCRIPTION
The only reliable source for the encoding description is the
creating software. In addition, encoding date is set and
basic bibliographic are copied to `biblFull`.