### PR TITLE
Add information on the manuscript-owning library

### DIFF
--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -162,13 +162,19 @@ class Mets:
 
 	#
 	# location of manuscript
-        location = self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:location[1]", namespaces=ns)[0]
-        self.shelf_locator = location.xpath("//mods:shelfLocator", namespaces=ns)[0].text
-        physical_location = location.xpath("//mods:physicalLocation", namespaces=ns)[0]
-        if physical_location.get("displayLabel", default="unspecified") != "unspecified":
-            self.owner_manuscript = physical_location.get("displayLabel")
-        else:
-            self.owner_manuscript = physical_location.text
+
+        # location-related elements are optional or conditional
+        location = self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:location[1]", namespaces=ns)
+        if location:
+            shelf_locator = self.shelf_locator = location[0].xpath("//mods:shelfLocator", namespaces=ns)
+            if shelf_locator:
+                self.shelf_locator = shelf_locator[0].text
+            physical_location = location[0].xpath("//mods:physicalLocation", namespaces=ns)
+            if physical_location:
+                if physical_location[0].get("displayLabel", default="unspecified") != "unspecified":
+                    self.owner_manuscript = physical_location[0].get("displayLabel")
+                else:
+                    self.owner_manuscript = physical_location[0].text
 
 
     def get_main_title(self):
@@ -255,7 +261,7 @@ class Mets:
         """
         return self.owner_manuscript
 
-    def get_shelf_loator(self):
+    def get_shelf_locator(self):
         """
         Return the shelf locator of the original manuscript
         """

--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -34,6 +34,8 @@ class Mets:
         self.license_url = None
         self.encoding_date = None
         self.encoding_desc = None
+        self.owner_manuscript = None
+        self.shelf_locator = None
 
     @classmethod
     def read(cls, source):
@@ -158,6 +160,16 @@ class Mets:
             if agent.get("OTHERTYPE") == "SOFTWARE":
                 self.encoding_desc = agent.xpath("//mets:name", namespaces=ns)[0].text
 
+	#
+	# location of manuscript
+        location = self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:location[1]", namespaces=ns)[0]
+        self.shelf_locator = location.xpath("//mods:shelfLocator", namespaces=ns)[0].text
+        physical_location = location.xpath("//mods:physicalLocation", namespaces=ns)[0]
+        if physical_location.get("displayLabel", default="unspecified") != "unspecified":
+            self.owner_manuscript = physical_location.get("displayLabel")
+        else:
+            self.owner_manuscript = physical_location.text
+
 
     def get_main_title(self):
         """
@@ -236,3 +248,15 @@ class Mets:
         Return details on the encoding of the digital edition
         """
         return self.encoding_desc
+
+    def get_owner_manuscript(self):
+        """
+        Return the owner of the original manuscript
+        """
+        return self.owner_manuscript
+
+    def get_shelf_loator(self):
+        """
+        Return the shelf locator of the original manuscript
+        """
+        return self.shelf_locator

--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -4,14 +4,38 @@ from lxml import etree
 
 import os
 
+import csv
+
+from pkg_resources import resource_filename, Requirement
+
 ns = {
      'mets': "http://www.loc.gov/METS/",
      'mods': "http://www.loc.gov/mods/v3",
-     'xlink' : "http://www.w3.org/1999/xlink",
-     'dv' : "http://dfg-viewer.de/",
+     'xlink': "http://www.w3.org/1999/xlink",
+     'dv': "http://dfg-viewer.de/",
 }
 METS = "{%s}" % ns['mets']
 XLINK = "{%s}" % ns['xlink']
+
+class Iso15924:
+
+    def __init__(self):
+        """
+        The constructor.
+        """
+        self.map = {}
+        filep = open(os.path.realpath(resource_filename(Requirement.parse("mets_mods2teiHeader"), 'mets_mods2teiHeader/data/iso15924-utf8-20180827.txt')))
+        reader = csv.DictReader(filter(lambda row: row[0]!='#', filep), delimiter=';', quoting=csv.QUOTE_NONE, fieldnames=['code','index','name_eng', 'name_fr', 'alias', 'Age', 'Date'])
+        for row in reader:
+            self.map[row['code']] = row['name_eng']
+        filep.close()
+
+    def get(self, code):
+        """
+        Return the description for the given code
+        :param str: An ISO 15924 code
+        """
+        return self.map.get(code, "Unknown")
 
 class Mets:
 
@@ -21,6 +45,8 @@ class Mets:
         """
 
         self.tree = None
+        self.script_iso = Iso15924()
+
         self.title = None
         self.sub_titles = None
         self.authors = None
@@ -36,6 +62,8 @@ class Mets:
         self.encoding_desc = None
         self.owner_manuscript = None
         self.shelf_locator = None
+        self.identifiers = None
+        self.scripts = None
 
     @classmethod
     def read(cls, source):
@@ -176,6 +204,22 @@ class Mets:
                 else:
                     self.owner_manuscript = physical_location[0].text
 
+        #
+        # identifiers
+        identifiers = self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:identifier", namespaces=ns)
+        self.identifiers = []
+        for identifier in identifiers:
+            self.identifiers.append((identifier.get("type", default="unknown"), identifier.text))
+
+        #
+        # scripts
+        scripts = self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:language/mods:scriptTerm", namespaces=ns)
+        self.scripts = []
+        for script in scripts:
+            self.scripts.append(self.script_iso.get(script.text))
+        if not self.scripts:
+            self.scripts.append(self.script_iso.get('Unknown'))
+
 
     def get_main_title(self):
         """
@@ -266,3 +310,15 @@ class Mets:
         Return the shelf locator of the original manuscript
         """
         return self.shelf_locator
+
+    def get_identifiers(self):
+        """
+        Return the mods identifiers as a attribut-value mapping
+        """
+        return self.identifiers
+
+    def get_scripts(self):
+        """
+        Returns information on the dominant fonts
+        """
+        return self.scripts

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -178,3 +178,12 @@ class Tei:
         ms_ident = self.tree.xpath('//tei:msDesc/tei:msIdentifier', namespaces=ns)[0]
         repository_node = etree.SubElement(ms_ident, "repository")
         repository_node.text = repository
+
+    def set_shelfmark(self, shelfmark):
+        """
+        Sets the shelf mark of the (original) manuscript
+        """
+        ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
+        idno = etree.SubElement(ms_ident_idno, "idno")
+        idno.set("type", "shelfmark")
+        idno.text = shelfmark

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -170,3 +170,11 @@ class Tei:
         encoding_desc = self.tree.xpath('//tei:encodingDesc', namespaces=ns)[0]
         encoding_desc_details = etree.SubElement(encoding_desc, "p")
         encoding_desc_details.text = "Encoded with the help of %s." % creator
+
+    def set_repository(self, repository):
+        """
+        Sets the repository of the (original) manuscript
+        """
+        ms_ident = self.tree.xpath('//tei:msDesc/tei:msIdentifier', namespaces=ns)[0]
+        repository_node = etree.SubElement(ms_ident, "repository")
+        repository_node.text = repository

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -171,19 +171,39 @@ class Tei:
         encoding_desc_details = etree.SubElement(encoding_desc, "p")
         encoding_desc_details.text = "Encoded with the help of %s." % creator
 
-    def set_repository(self, repository):
+    def add_repository(self, repository):
         """
-        Sets the repository of the (original) manuscript
+        Adds the repository of the (original) manuscript
         """
         ms_ident = self.tree.xpath('//tei:msDesc/tei:msIdentifier', namespaces=ns)[0]
         repository_node = etree.SubElement(ms_ident, "repository")
         repository_node.text = repository
 
-    def set_shelfmark(self, shelfmark):
+    def add_shelfmark(self, shelfmark):
         """
-        Sets the shelf mark of the (original) manuscript
+        Adds the shelf mark of the (original) manuscript
         """
         ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
         idno = etree.SubElement(ms_ident_idno, "idno")
         idno.set("type", "shelfmark")
         idno.text = shelfmark
+
+    def add_identifiers(self, identifiers):
+        """
+        Adds the identifiers of the digital edition
+        """
+        ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
+        for identifier in identifiers:
+            idno = etree.SubElement(ms_ident_idno, "idno")
+            idno.set("type", identifier[0])
+            idno.text = identifier[1]
+
+    def set_type_desc(self, description):
+        """
+        Sets the type description
+        """
+        phys_desc = self.tree.xpath('//tei:msDesc/tei:physDesc', namespaces=ns)[0]
+        type_desc = etree.SubElement(phys_desc, "typeDesc")
+        for line in description.split('\n'):
+            par = etree.SubElement(type_desc, "p")
+            par.text = line

--- a/mets_mods2teiHeader/data/iso15924-utf8-20180827.txt
+++ b/mets_mods2teiHeader/data/iso15924-utf8-20180827.txt
@@ -1,0 +1,206 @@
+#
+# ISO 15924 - Codes for the representation of names of scripts
+#             Codes pour la représentation des noms d’écritures
+# Format: 
+#             Code;N°;English Name;Nom français;PVA;Unicode Version;Date
+#
+
+Adlm;166;Adlam;adlam;Adlam;9.0;2016-12-05
+Afak;439;Afaka;afaka;;;2010-12-21
+Aghb;239;Caucasian Albanian;aghbanien;Caucasian_Albanian;7.0;2014-11-15
+Ahom;338;Ahom, Tai Ahom;âhom;Ahom;8.0;2015-07-07
+Arab;160;Arabic;arabe;Arabic;1.1;2004-05-01
+Aran;161;Arabic (Nastaliq variant);arabe (variante nastalique);;1.1;2014-11-15
+Armi;124;Imperial Aramaic;araméen impérial;Imperial_Aramaic;5.2;2009-06-01
+Armn;230;Armenian;arménien;Armenian;1.1;2004-05-01
+Avst;134;Avestan;avestique;Avestan;5.2;2009-06-01
+Bali;360;Balinese;balinais;Balinese;5.0;2006-10-10
+Bamu;435;Bamum;bamoum;Bamum;5.2;2009-06-01
+Bass;259;Bassa Vah;bassa;Bassa_Vah;7.0;2014-11-15
+Batk;365;Batak;batik;Batak;6.0;2010-07-23
+Beng;325;Bengali (Bangla);bengalî (bangla);Bengali;1.1;2016-12-05
+Bhks;334;Bhaiksuki;bhaïksukî;Bhaiksuki;9.0;2016-12-05
+Blis;550;Blissymbols;symboles Bliss;;;2004-05-01
+Bopo;285;Bopomofo;bopomofo;Bopomofo;1.1;2004-05-01
+Brah;300;Brahmi;brahma;Brahmi;6.0;2010-07-23
+Brai;570;Braille;braille;Braille;3.0;2004-05-01
+Bugi;367;Buginese;bouguis;Buginese;4.1;2006-06-21
+Buhd;372;Buhid;bouhide;Buhid;3.2;2004-05-01
+Cakm;349;Chakma;chakma;Chakma;6.1;2012-02-06
+Cans;440;Unified Canadian Aboriginal Syllabics;syllabaire autochtone canadien unifié;Canadian_Aboriginal;3.0;2004-05-29
+Cari;201;Carian;carien;Carian;5.1;2007-07-02
+Cham;358;Cham;cham (čam, tcham);Cham;5.1;2009-11-11
+Cher;445;Cherokee;tchérokî;Cherokee;3.0;2004-05-01
+Cirt;291;Cirth;cirth;;;2004-05-01
+Copt;204;Coptic;copte;Coptic;4.1;2006-06-21
+Cpmn;402;Cypro-Minoan;syllabaire chypro-minoen;;;2017-07-26
+Cprt;403;Cypriot syllabary;syllabaire chypriote;Cypriot;4.0;2017-07-26
+Cyrl;220;Cyrillic;cyrillique;Cyrillic;1.1;2004-05-01
+Cyrs;221;Cyrillic (Old Church Slavonic variant);cyrillique (variante slavonne);;1.1;2004-05-01
+Deva;315;Devanagari (Nagari);dévanâgarî;Devanagari;1.1;2004-05-01
+Dogr;328;Dogra;dogra;Dogra;11.0;2016-12-05
+Dsrt;250;Deseret (Mormon);déseret (mormon);Deseret;3.1;2004-05-01
+Dupl;755;Duployan shorthand, Duployan stenography;sténographie Duployé;Duployan;7.0;2014-11-15
+Egyd;070;Egyptian demotic;démotique égyptien;;;2004-05-01
+Egyh;060;Egyptian hieratic;hiératique égyptien;;5.2;2004-05-01
+Egyp;050;Egyptian hieroglyphs;hiéroglyphes égyptiens;Egyptian_Hieroglyphs;5.2;2009-06-01
+Elba;226;Elbasan;elbasan;Elbasan;7.0;2014-11-15
+Elym;128;Elymaic;élymaïque;Elymaic;12.0;2018-08-26
+Ethi;430;Ethiopic (Geʻez);éthiopien (geʻez, guèze);Ethiopic;3.0;2004-10-25
+Geok;241;Khutsuri (Asomtavruli and Nuskhuri);khoutsouri (assomtavrouli et nouskhouri);Georgian;1.1;2012-10-16
+Geor;240;Georgian (Mkhedruli and Mtavruli);géorgien (mkhédrouli et mtavrouli);Georgian;1.1;2016-12-05
+Glag;225;Glagolitic;glagolitique;Glagolitic;4.1;2006-06-21
+Gong;312;Gunjala Gondi;gunjala gondî;Gunjala_Gondi;11.0;2016-12-05
+Gonm;313;Masaram Gondi;masaram gondî;Masaram_Gondi;10.0;2017-07-26
+Goth;206;Gothic;gotique;Gothic;3.1;2004-05-01
+Gran;343;Grantha;grantha;Grantha;7.0;2014-11-15
+Grek;200;Greek;grec;Greek;1.1;2004-05-01
+Gujr;320;Gujarati;goudjarâtî (gujrâtî);Gujarati;1.1;2004-05-01
+Guru;310;Gurmukhi;gourmoukhî;Gurmukhi;1.1;2004-05-01
+Hanb;503;Han with Bopomofo (alias for Han + Bopomofo);han avec bopomofo (alias pour han + bopomofo);;1.1;2016-01-19
+Hang;286;Hangul (Hangŭl, Hangeul);hangûl (hangŭl, hangeul);Hangul;1.1;2004-05-29
+Hani;500;Han (Hanzi, Kanji, Hanja);idéogrammes han (sinogrammes);Han;1.1;2009-02-23
+Hano;371;Hanunoo (Hanunóo);hanounóo;Hanunoo;3.2;2004-05-29
+Hans;501;Han (Simplified variant);idéogrammes han (variante simplifiée);;1.1;2004-05-29
+Hant;502;Han (Traditional variant);idéogrammes han (variante traditionnelle);;1.1;2004-05-29
+Hatr;127;Hatran;hatrénien;Hatran;8.0;2015-07-07
+Hebr;125;Hebrew;hébreu;Hebrew;1.1;2004-05-01
+Hira;410;Hiragana;hiragana;Hiragana;1.1;2004-05-01
+Hluw;080;Anatolian Hieroglyphs (Luwian Hieroglyphs, Hittite Hieroglyphs);hiéroglyphes anatoliens (hiéroglyphes louvites, hiéroglyphes hittites);Anatolian_Hieroglyphs;8.0;2015-07-07
+Hmng;450;Pahawh Hmong;pahawh hmong;Pahawh_Hmong;7.0;2014-11-15
+Hmnp;451;Nyiakeng Puachue Hmong;nyiakeng puachue hmong;Nyiakeng_Puachue_Hmong;12.0;2017-07-26
+Hrkt;412;Japanese syllabaries (alias for Hiragana + Katakana);syllabaires japonais (alias pour hiragana + katakana);Katakana_Or_Hiragana;1.1;2011-06-21
+Hung;176;Old Hungarian (Hungarian Runic);runes hongroises (ancien hongrois);Old_Hungarian;8.0;2015-07-07
+Inds;610;Indus (Harappan);indus;;;2004-05-01
+Ital;210;Old Italic (Etruscan, Oscan, etc.);ancien italique (étrusque, osque, etc.);Old_Italic;3.1;2004-05-29
+Jamo;284;Jamo (alias for Jamo subset of Hangul);jamo (alias pour le sous-ensemble jamo du hangûl);;1.1;2016-01-19
+Java;361;Javanese;javanais;Javanese;5.2;2009-06-01
+Jpan;413;Japanese (alias for Han + Hiragana + Katakana);japonais (alias pour han + hiragana + katakana);;1.1;2006-06-21
+Jurc;510;Jurchen;jurchen;;;2010-12-21
+Kali;357;Kayah Li;kayah li;Kayah_Li;5.1;2007-07-02
+Kana;411;Katakana;katakana;Katakana;1.1;2004-05-01
+Khar;305;Kharoshthi;kharochthî;Kharoshthi;4.1;2006-06-21
+Khmr;355;Khmer;khmer;Khmer;3.0;2004-05-29
+Khoj;322;Khojki;khojkî;Khojki;7.0;2014-11-15
+Kitl;505;Khitan large script;grande écriture khitan;;;2015-07-15
+Kits;288;Khitan small script;petite écriture khitan;;;2015-07-15
+Knda;345;Kannada;kannara (canara);Kannada;1.1;2004-05-29
+Kore;287;Korean (alias for Hangul + Han);coréen (alias pour hangûl + han);;1.1;2007-06-13
+Kpel;436;Kpelle;kpèllé;;;2010-03-26
+Kthi;317;Kaithi;kaithî;Kaithi;5.2;2009-06-01
+Lana;351;Tai Tham (Lanna);taï tham (lanna);Tai_Tham;5.2;2009-06-01
+Laoo;356;Lao;laotien;Lao;1.1;2004-05-01
+Latf;217;Latin (Fraktur variant);latin (variante brisée);;1.1;2004-05-01
+Latg;216;Latin (Gaelic variant);latin (variante gaélique);;1.1;2004-05-01
+Latn;215;Latin;latin;Latin;1.1;2004-05-01
+Leke;364;Leke;léké;;;2015-07-07
+Lepc;335;Lepcha (Róng);lepcha (róng);Lepcha;5.1;2007-07-02
+Limb;336;Limbu;limbou;Limbu;4.0;2004-05-29
+Lina;400;Linear A;linéaire A;Linear_A;7.0;2014-11-15
+Linb;401;Linear B;linéaire B;Linear_B;4.0;2004-05-29
+Lisu;399;Lisu (Fraser);lisu (Fraser);Lisu;5.2;2009-06-01
+Loma;437;Loma;loma;;;2010-03-26
+Lyci;202;Lycian;lycien;Lycian;5.1;2007-07-02
+Lydi;116;Lydian;lydien;Lydian;5.1;2007-07-02
+Mahj;314;Mahajani;mahâjanî;Mahajani;7.0;2014-11-15
+Maka;366;Makasar;makassar;Makasar;11.0;2016-12-05
+Mand;140;Mandaic, Mandaean;mandéen;Mandaic;6.0;2010-07-23
+Mani;139;Manichaean;manichéen;Manichaean;7.0;2014-11-15
+Marc;332;Marchen;marchen;Marchen;9.0;2016-12-05
+Maya;090;Mayan hieroglyphs;hiéroglyphes mayas;;;2004-05-01
+Medf;265;Medefaidrin (Oberi Okaime, Oberi Ɔkaimɛ);médéfaïdrine;Medefaidrin;11.0;2016-12-05
+Mend;438;Mende Kikakui;mendé kikakui;Mende_Kikakui;7.0;2014-11-15
+Merc;101;Meroitic Cursive;cursif méroïtique;Meroitic_Cursive;6.1;2012-02-06
+Mero;100;Meroitic Hieroglyphs;hiéroglyphes méroïtiques;Meroitic_Hieroglyphs;6.1;2012-02-06
+Mlym;347;Malayalam;malayâlam;Malayalam;1.1;2004-05-01
+Modi;324;Modi, Moḍī;modî;Modi;7.0;2014-11-15
+Mong;145;Mongolian;mongol;Mongolian;3.0;2004-05-01
+Moon;218;Moon (Moon code, Moon script, Moon type);écriture Moon;;;2006-12-11
+Mroo;264;Mro, Mru;mro;Mro;7.0;2016-12-05
+Mtei;337;Meitei Mayek (Meithei, Meetei);meitei mayek;Meetei_Mayek;5.2;2009-06-01
+Mult;323;Multani;multanî;Multani;8.0;2015-07-07
+Mymr;350;Myanmar (Burmese);birman;Myanmar;3.0;2004-05-01
+Nand;311;Nandinagari;nandinâgarî;Nandinagari;12.0;2018-08-26
+Narb;106;Old North Arabian (Ancient North Arabian);nord-arabique;Old_North_Arabian;7.0;2014-11-15
+Nbat;159;Nabataean;nabatéen;Nabataean;7.0;2014-11-15
+Newa;333;Newa, Newar, Newari, Nepāla lipi;néwa, néwar, néwari, nepāla lipi;Newa;9.0;2016-12-05
+Nkdb;085;Naxi Dongba (na²¹ɕi³³ to³³ba²¹, Nakhi Tomba);naxi dongba;;;2017-07-26
+Nkgb;420;Naxi Geba (na²¹ɕi³³ gʌ²¹ba²¹, 'Na-'Khi ²Ggŏ-¹baw, Nakhi Geba);naxi geba, nakhi geba;;;2017-07-26
+Nkoo;165;N’Ko;n’ko;Nko;5.0;2006-10-10
+Nshu;499;Nüshu;nüshu;Nushu;10.0;2017-07-26
+Ogam;212;Ogham;ogam;Ogham;3.0;2004-05-01
+Olck;261;Ol Chiki (Ol Cemet’, Ol, Santali);ol tchiki;Ol_Chiki;5.1;2007-07-02
+Orkh;175;Old Turkic, Orkhon Runic;orkhon;Old_Turkic;5.2;2009-06-01
+Orya;327;Oriya (Odia);oriyâ (odia);Oriya;1.1;2016-12-05
+Osge;219;Osage;osage;Osage;9.0;2016-12-05
+Osma;260;Osmanya;osmanais;Osmanya;4.0;2004-05-01
+Palm;126;Palmyrene;palmyrénien;Palmyrene;7.0;2014-11-15
+Pauc;263;Pau Cin Hau;paou chin haou;Pau_Cin_Hau;7.0;2014-11-15
+Perm;227;Old Permic;ancien permien;Old_Permic;7.0;2014-11-15
+Phag;331;Phags-pa;’phags pa;Phags_Pa;5.0;2006-10-10
+Phli;131;Inscriptional Pahlavi;pehlevi des inscriptions;Inscriptional_Pahlavi;5.2;2009-06-01
+Phlp;132;Psalter Pahlavi;pehlevi des psautiers;Psalter_Pahlavi;7.0;2014-11-15
+Phlv;133;Book Pahlavi;pehlevi des livres;;;2007-07-15
+Phnx;115;Phoenician;phénicien;Phoenician;5.0;2006-10-10
+Plrd;282;Miao (Pollard);miao (Pollard);Miao;6.1;2012-02-06
+Piqd;293;Klingon (KLI pIqaD);klingon (pIqaD du KLI);;;2015-12-16
+Prti;130;Inscriptional Parthian;parthe des inscriptions;Inscriptional_Parthian;5.2;2009-06-01
+Qaaa;900;Reserved for private use (start);réservé à l’usage privé (début);;;2004-05-29
+Qabx;949;Reserved for private use (end);réservé à l’usage privé (fin);;;2004-05-29
+Rjng;363;Rejang (Redjang, Kaganga);redjang (kaganga);Rejang;5.1;2009-02-23
+Rohg;167;Hanifi Rohingya;hanifi rohingya;Hanifi_Rohingya;11.0;2017-11-21
+Roro;620;Rongorongo;rongorongo;;;2004-05-01
+Runr;211;Runic;runique;Runic;3.0;2004-05-01
+Samr;123;Samaritan;samaritain;Samaritan;5.2;2009-06-01
+Sara;292;Sarati;sarati;;;2004-05-29
+Sarb;105;Old South Arabian;sud-arabique, himyarite;Old_South_Arabian;5.2;2009-06-01
+Saur;344;Saurashtra;saurachtra;Saurashtra;5.1;2007-07-02
+Sgnw;095;SignWriting;SignÉcriture, SignWriting;SignWriting;8.0;2015-07-07
+Shaw;281;Shavian (Shaw);shavien (Shaw);Shavian;4.0;2004-05-01
+Shrd;319;Sharada, Śāradā;charada, shard;Sharada;6.1;2012-02-06
+Shui;530;Shuishu;shuishu;;;2017-07-26
+Sidd;302;Siddham, Siddhaṃ, Siddhamātṛkā;siddham;Siddham;7.0;2014-11-15
+Sind;318;Khudawadi, Sindhi;khoudawadî, sindhî;Khudawadi;7.0;2014-11-15
+Sinh;348;Sinhala;singhalais;Sinhala;3.0;2004-05-01
+Sogd;141;Sogdian;sogdien;Sogdian;11.0;2017-11-21
+Sogo;142;Old Sogdian;ancien sogdien;Old_Sogdian;11.0;2017-11-21
+Sora;398;Sora Sompeng;sora sompeng;Sora_Sompeng;6.1;2012-02-06
+Soyo;329;Soyombo;soyombo;Soyombo;10.0;2017-07-26
+Sund;362;Sundanese;sundanais;Sundanese;5.1;2007-07-02
+Sylo;316;Syloti Nagri;sylotî nâgrî;Syloti_Nagri;4.1;2006-06-21
+Syrc;135;Syriac;syriaque;Syriac;3.0;2004-05-01
+Syre;138;Syriac (Estrangelo variant);syriaque (variante estranghélo);;3.0;2004-05-01
+Syrj;137;Syriac (Western variant);syriaque (variante occidentale);;3.0;2004-05-01
+Syrn;136;Syriac (Eastern variant);syriaque (variante orientale);;3.0;2004-05-01
+Tagb;373;Tagbanwa;tagbanoua;Tagbanwa;3.2;2004-05-01
+Takr;321;Takri, Ṭākrī, Ṭāṅkrī;tâkrî;Takri;6.1;2012-02-06
+Tale;353;Tai Le;taï-le;Tai_Le;4.0;2004-10-25
+Talu;354;New Tai Lue;nouveau taï-lue;New_Tai_Lue;4.1;2006-06-21
+Taml;346;Tamil;tamoul;Tamil;1.1;2004-05-01
+Tang;520;Tangut;tangoute;Tangut;9.0;2016-12-05
+Tavt;359;Tai Viet;taï viêt;Tai_Viet;5.2;2009-06-01
+Telu;340;Telugu;télougou;Telugu;1.1;2004-05-01
+Teng;290;Tengwar;tengwar;;;2004-05-01
+Tfng;120;Tifinagh (Berber);tifinagh (berbère);Tifinagh;4.1;2006-06-21
+Tglg;370;Tagalog (Baybayin, Alibata);tagal (baybayin, alibata);Tagalog;3.2;2009-02-23
+Thaa;170;Thaana;thâna;Thaana;3.0;2004-05-01
+Thai;352;Thai;thaï;Thai;1.1;2004-05-01
+Tibt;330;Tibetan;tibétain;Tibetan;2.0;2004-05-01
+Tirh;326;Tirhuta;tirhouta;Tirhuta;7.0;2014-11-15
+Ugar;040;Ugaritic;ougaritique;Ugaritic;4.0;2004-05-01
+Vaii;470;Vai;vaï;Vai;5.1;2007-07-02
+Visp;280;Visible Speech;parole visible;;;2004-05-01
+Wara;262;Warang Citi (Varang Kshiti);warang citi;Warang_Citi;7.0;2014-11-15
+Wcho;283;Wancho;wantcho;Wancho;12.0;2017-07-26
+Wole;480;Woleai;woléaï;;;2010-12-21
+Xpeo;030;Old Persian;cunéiforme persépolitain;Old_Persian;4.1;2006-06-21
+Xsux;020;Cuneiform, Sumero-Akkadian;cunéiforme suméro-akkadien;Cuneiform;5.0;2006-10-10
+Yiii;460;Yi;yi;Yi;3.0;2004-05-01
+Zanb;339;Zanabazar Square (Zanabazarin Dörböljin Useg, Xewtee Dörböljin Bicig, Horizontal Square Script);zanabazar quadratique;Zanabazar_Square;10.0;2017-07-26
+Zinh;994;Code for inherited script;codet pour écriture héritée;Inherited;;2009-02-23
+Zmth;995;Mathematical notation;notation mathématique;;3.2;2007-11-26
+Zsye;993;Symbols (Emoji variant);symboles (variante émoji);;6.0;2015-12-16
+Zsym;996;Symbols;symboles;;1.1;2007-11-26
+Zxxx;997;Code for unwritten documents;codet pour les documents non écrits;;;2011-06-21
+Zyyy;998;Code for undetermined script;codet pour écriture indéterminée;Common;;2004-05-29
+Zzzz;999;Code for uncoded script;codet pour écriture non codée;Unknown;;2006-10-10

--- a/mets_mods2teiHeader/data/tei_skeleton.xml
+++ b/mets_mods2teiHeader/data/tei_skeleton.xml
@@ -24,7 +24,6 @@
         <msDesc>
           <msIdentifier>
             <idno>
-              <idno type="shelfmark">[Signatur]</idno>
               <idno type="URLCatalogue">[URL Katalogaufnahme]</idno>
               <idno type="URLImages">[URL Bilddateien]</idno>
             </idno>

--- a/mets_mods2teiHeader/data/tei_skeleton.xml
+++ b/mets_mods2teiHeader/data/tei_skeleton.xml
@@ -23,7 +23,6 @@
         </biblFull>
         <msDesc>
           <msIdentifier>
-            <repository>[besitzende Bibliothek]</repository>
             <idno>
               <idno type="shelfmark">[Signatur]</idno>
               <idno type="URLCatalogue">[URL Katalogaufnahme]</idno>

--- a/mets_mods2teiHeader/data/tei_skeleton.xml
+++ b/mets_mods2teiHeader/data/tei_skeleton.xml
@@ -24,14 +24,9 @@
         <msDesc>
           <msIdentifier>
             <idno>
-              <idno type="URLCatalogue">[URL Katalogaufnahme]</idno>
-              <idno type="URLImages">[URL Bilddateien]</idno>
             </idno>
           </msIdentifier>
           <physDesc>
-            <typeDesc>
-              <p>[vorrangige Schriftart des zugrundeliegenden Textbandes]</p>
-            </typeDesc>
           </physDesc>
         </msDesc>
       </sourceDesc>

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -75,9 +75,19 @@ def cli(mets):
 
     # repository
     if mets.get_owner_manuscript():
-        tei.set_repository(mets.get_owner_manuscript())
+        tei.add_repository(mets.get_owner_manuscript())
+
+    # shelf locator
     if mets.get_shelf_locator():
-        tei.set_shelfmark(mets.get_shelf_locator())
+        tei.add_shelfmark(mets.get_shelf_locator())
+
+    # identifiers
+    if mets.get_identifiers():
+        tei.add_identifiers(mets.get_identifiers())
+
+    # type description
+    if mets.get_scripts():
+        tei.set_type_desc('\n'.join(script for script in mets.get_scripts()))
 
     click.echo(tei.tostring())
 

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -74,7 +74,10 @@ def cli(mets):
     tei.set_encoding_description(mets.get_encoding_description())
 
     # repository
-    tei.set_repository(mets.get_owner_manuscript())
+    if mets.get_owner_manuscript():
+        tei.set_repository(mets.get_owner_manuscript())
+    if mets.get_shelf_locator():
+        tei.set_shelfmark(mets.get_shelf_locator())
 
     click.echo(tei.tostring())
 

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -73,6 +73,9 @@ def cli(mets):
     tei.set_encoding_date(mets.get_encoding_date())
     tei.set_encoding_description(mets.get_encoding_description())
 
+    # repository
+    tei.set_repository(mets.get_owner_manuscript())
+
     click.echo(tei.tostring())
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='kay-michael.wuerzner@slub-dresden.de',
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
-    package_data={'mets_mods2teiHeader' : ['data/tei_skeleton.xml']},
+    package_data={'mets_mods2teiHeader' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
     install_requires=[
     ],
     entry_points={


### PR DESCRIPTION
The information is added to the `repository` node in the manuscript
description.