### PR TITLE
Circle coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,11 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: python:3.6
     working_directory: ~/repo
     steps:
       - checkout
-      - run:
-          name: install dependencies
-          command: |
-            pip install -r requirements-test.txt
-            pip install .
+      - run: pip install -r requirements-test.txt
+      - run: pip install .
       - run: make coverage
       - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,44 +9,14 @@ orbs:
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/python:3.6.1
-
     working_directory: ~/repo
-
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt .
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      # run tests!
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            py.test
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
-
-      # code coverage
-      - codecov/upload:
-          token: 7f1ff644-66b9-4908-a170-b0a070113680
+            pip install -r requirements-test.txt
+            pip install .
+      - run: make coverage
+      - codecov/upload

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = mets_mods2teiHeader
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Python interpreter. Default: '$(PYTHON)'
+PYTHON = python
+
+# BEGIN-EVAL makefile-parser --make-help Makefile
+
+help:
+	@echo ""
+	@echo "  Targets"
+	@echo ""
+	@echo "    test      Run all unit tests"
+	@echo "    coverage  Run coverage tests"
+	@echo ""
+	@echo "  Variables"
+	@echo ""
+	@echo "    PYTHON  Python interpreter. Default: '$(PYTHON)'"
+
+# END-EVAL
+
+#
+# Tests
+#
+
+.PHONY: test coverage
+
+# Run all unit tests
+test:
+	$(PYTHON) -m pytest --continue-on-collection-errors $(TESTDIR)
+
+# Run coverage tests
+coverage:
+	coverage erase
+	make test PYTHON="coverage run"
+	coverage report
+	coverage html

--- a/README.md
+++ b/README.md
@@ -50,17 +50,25 @@ $ . env/bin/activate
 ```
 
 ### Python requirements
-`mets-mods2teiHeader` uses various 3rd party Python packages which may best be installed using `pip`:
-```console
-(env) $ pip install -r requirements.txt
-```
-Finally, `mets-mods2teiHeader` itself can be installed via `pip`:
+
+`mets-mods2teiHeader` can be installed via `pip`:
+
 ```console
 (env) $ pip install .
 ```
 
 ## Testing
-`mets-mods2teiHeader` uses `pytest`-based testing. Run the tests via:
+
+`mets-mods2teiHeader` uses `pytest`-based testing.
+
+Install the test requirements:
+
+```console
+(env) pip install -r requirements-test.txt
+```
+
+Run the tests via:
+
 ```console
 (env) $ pytest
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Run the tests via:
 (env) $ pytest
 ```
 
+## Code coverage
+
+Determine code coverage by running
+
+```console
+(env) $ make coverage
+```
+
 ## Invocation
 Installing `mets-mods2teiHeader` makes the command line tool `mods2teiHeader` available:
 ```console

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-ordering
+pytest-subtests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest
+pytest >= 4.4.0
 pytest-ordering
 pytest-subtests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest >= 4.4.0
 pytest-ordering
 pytest-subtests
+coverage >= 4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 click
 lxml
 babel
-pytest
-pytest-ordering
-pytest-subtests

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license = open('LICENSE').read(),
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'mets_mods2teiHeader' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
-    install_requires=open('requirements-test.txt').read().split('\n'),
+    install_requires=open('requirements.txt').read().split('\n'),
     entry_points={
           'console_scripts': [
               'mods2teiHeader=mets_mods2teiHeader.scripts.mets_mods2teiHeader:cli',

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,18 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as f:
-    readme = f.read()
-
-with open('LICENSE') as f:
-    license = f.read()
-
 setup(
     name='mets-mods2teiHeader',
     version='0.0.1',
     description='Convert bibliographic meta data in MODS format to TEI headers',
-    long_description=readme,
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     author='Kay-Michael Würzner',
     author_email='kay-michael.wuerzner@slub-dresden.de',
-    license=license,
+    license = open('LICENSE').read(),
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'mets_mods2teiHeader' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
-    install_requires=[
-    ],
+    install_requires=open('requirements-test.txt').read().split('\n'),
     entry_points={
           'console_scripts': [
               'mods2teiHeader=mets_mods2teiHeader.scripts.mets_mods2teiHeader:cli',

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -32,7 +32,7 @@ def test_constructor():
     Test the creation of an empty Mets instance
     '''
     mets = Mets()
-    assert(mets.tree == None)
+    assert(mets.tree is None)
 
 def test_reading_local_file(datadir):
     '''
@@ -40,7 +40,7 @@ def test_reading_local_file(datadir):
     '''
     f = open(datadir.join('test_mets.xml'))
     mets = Mets.read(f)
-    assert(mets.tree != None)
+    assert(mets.tree is not None)
 
 def test_loading_local_file(datadir):
     '''
@@ -48,7 +48,7 @@ def test_loading_local_file(datadir):
     '''
     f = open(datadir.join('test_mets.xml'))
     mets = Mets.fromfile(f)
-    assert(mets.tree != None)
+    assert(mets.tree is not None)
 
 def test_data_assignment(subtests, datadir):
     '''


### PR DESCRIPTION
* split requirements in test and prod requirements
* setup.py reads install_requires from requirements.txt
* makefile because makefiles are the best
* coveragerc setup, run locally with `make coverage`
* simplified circle ci setup based on vanilla python docker image and no caching
* codecov should be integrated