### PR TITLE
Add the source document's extent to TEI

### DIFF
--- a/mets_mods2teiHeader/api/mets.py
+++ b/mets_mods2teiHeader/api/mets.py
@@ -69,6 +69,7 @@ class Mets:
         self.scripts = None
         self.collections = None
         self.languages = None
+        self.extents = None
 
     @classmethod
     def read(cls, source):
@@ -252,6 +253,11 @@ class Mets:
         if not self.languages:
             self.languages['mis'] = 'Unkodiert'
 
+        #
+        # extent
+        self.extents = []
+        for extent in self.tree.xpath("//mets:dmdSec[1]//mods:mods/mods:physicalDescription[1]/mods:extent", namespaces=ns):
+            self.extents.append(extent.text)
 
     def get_main_title(self):
         """

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -225,3 +225,16 @@ class Tei:
         lang = etree.SubElement(lang_usage, "language")
         lang.set("ident", language[0])
         lang.text = language[1]
+
+    def add_extent(self, extent):
+        """
+        Add information on the extent of the source document
+        """
+        phys_desc = self.tree.xpath('//tei:msDesc/tei:physDesc', namespaces=ns)[0]
+        if phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns) == []:
+            obj_desc = etree.SubElement(phys_desc, "objectDesc")
+            support_desc = etree.SubElement(obj_desc, "supportDesc")
+        else:
+            support_desc = phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns)[0]
+        extent_elem = etree.SubElement(support_desc, "extent")
+        extent_elem.text = extent

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -245,5 +245,5 @@ class Tei:
             support_desc = etree.SubElement(obj_desc, "%ssupportDesc" % TEI)
         else:
             support_desc = phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns)[0]
-        extent_elem = etree.SubElement(support_desc, "{%s}extent" % TEI)
+        extent_elem = etree.SubElement(support_desc, "%sextent" % TEI)
         extent_elem.text = extent

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -28,12 +28,21 @@ class Tei:
         """
         return etree.tostring(self.tree, encoding="utf-8")
 
-    def get_main_title(self):
+    @property
+    def main_title(self):
         """
         Returns the main title of the work represented
         by the TEI Header.
         """
         return self.tree.xpath('//tei:titleStmt/tei:title[@type="main"]', namespaces=ns)[0].text
+
+    @property
+    def extents(self):
+        """
+        Returns information on the extent of the work represented
+        by the TEI Header.
+        """
+        return [extent.text for extent in self.tree.xpath('//tei:msDesc/tei:physDesc/tei:objectDesc/tei:supportDesc/tei:extent', namespaces=ns)]
 
     def set_main_title(self, string):
         """
@@ -58,21 +67,21 @@ class Tei:
         """
         author = etree.Element("author")
         if typ == "personal":
-            pers_name = etree.SubElement(author, "persName")
+            pers_name = etree.SubElement(author, "%spersName" % TEI)
             for key in person:
                 if key == "family":
-                    surname = etree.SubElement(pers_name, "surname")
+                    surname = etree.SubElement(pers_name, "%ssurname" % TEI)
                     surname.text = person[key]
                 elif key == "given":
-                    forename = etree.SubElement(pers_name, "forename")
+                    forename = etree.SubElement(pers_name, "%sforename" % TEI)
                     forename.text = person[key]
                 elif key == "date" or key == "unspecified":
                     continue
                 else:
-                    add_name = etree.SubElement(pers_name, "addName")
+                    add_name = etree.SubElement(pers_name, "%saddName" % TEI)
                     add_name.text = person[key]
         elif typ == "corporate":
-            org_name = etree.SubElement(author, "orgName")
+            org_name = etree.SubElement(author, "%sorgName" % TEI)
             org_name.text = " ".join(person[key] for key in person)
         for title_stmt in self.tree.xpath('//tei:titleStmt', namespaces=ns):
             title_stmt.append(copy.deepcopy(author))
@@ -82,7 +91,7 @@ class Tei:
         Adds a publication place to the publication statement.
         """
         publication_stmt = self.tree.xpath('//tei:fileDesc/tei:sourceDesc/tei:biblFull/tei:publicationStmt', namespaces=ns)[0]
-        pub_place = etree.SubElement(publication_stmt, "pubPlace")
+        pub_place = etree.SubElement(publication_stmt, "%spubPlace" % TEI)
         for key in place:
             if key == "text":
                 pub_place.text = place[key]
@@ -95,7 +104,7 @@ class Tei:
         """
         publication_stmt = self.tree.xpath('//tei:fileDesc/tei:sourceDesc/tei:biblFull/tei:publicationStmt', namespaces=ns)[0]
         for key in date:
-            pub_date = etree.SubElement(publication_stmt, "date")
+            pub_date = etree.SubElement(publication_stmt, "%sdate" % TEI)
             pub_date.set("type", "publication")
             pub_date.text = date[key]
             if key != "unspecified":
@@ -107,7 +116,7 @@ class Tei:
         """
         publication_stmt = self.tree.xpath('//tei:fileDesc/tei:sourceDesc/tei:biblFull/tei:publicationStmt', namespaces=ns)[0]
         publisher_node = etree.Element("publisher")
-        name = etree.SubElement(publisher_node, "name")
+        name = etree.SubElement(publisher_node, "%sname" % TEI)
         name.text = publisher
         publication_stmt.insert(0, publisher_node)
 
@@ -116,8 +125,8 @@ class Tei:
         Adds an edition statement with details on the source manuscript.
         """
         bibl_full = self.tree.xpath('//tei:fileDesc/tei:sourceDesc/tei:biblFull', namespaces=ns)[0]
-        edition_stmt = etree.SubElement(bibl_full, "editionStmt")
-        edition = etree.SubElement(edition_stmt, "edition")
+        edition_stmt = etree.SubElement(bibl_full, "%seditionStmt" % TEI)
+        edition = etree.SubElement(edition_stmt, "%sedition" % TEI)
         edition.text = manuscript_edition
 
     def add_digital_edition(self, digital_edition):
@@ -125,8 +134,8 @@ class Tei:
         Adds an edition statement with details on the digital edition.
         """
         title_stmt = self.tree.xpath('//tei:titleStmt', namespaces=ns)[0]
-        edition_stmt = etree.SubElement(title_stmt, "editionStmt")
-        edition = etree.SubElement(edition_stmt, "edition")
+        edition_stmt = etree.SubElement(title_stmt, "%seditionStmt" % TEI)
+        edition = etree.SubElement(edition_stmt, "%sedition" % TEI)
         edition.text = digital_edition
 
     def set_hoster(self, hoster):
@@ -134,7 +143,7 @@ class Tei:
         Set the publisher of the digital edition
         """
         publication_stmt = self.tree.xpath('//tei:publicationStmt', namespaces=ns)[0]
-        publisher = etree.SubElement(publication_stmt, "publisher")
+        publisher = etree.SubElement(publication_stmt, "%spublisher" % TEI)
         publisher.text = hoster
 
     def set_availability(self, status, licence_text, licence_url):
@@ -142,17 +151,17 @@ class Tei:
         Set the availability conditions of the digital edition
         """
         publication_stmt = self.tree.xpath('//tei:publicationStmt', namespaces=ns)[0]
-        availability = etree.SubElement(publication_stmt, "availability")
+        availability = etree.SubElement(publication_stmt, "%savailability" % TEI)
         
         # an explicit licence has been set
         if status == "licence" and licence_text != "":
-            licence = etree.SubElement(availability, "licence")
+            licence = etree.SubElement(availability, "%slicence" % TEI)
             licence.text = licence_text
             if licence_url != "":
                 licence.set("target", licence_url)
         # public domain
         elif status == "free":
-            note = etree.SubElement(availability, "p")
+            note = etree.SubElement(availability, "%sp" % TEI)
             note.text = "In the public domain"
             availability.set("status", "free")
         elif status == "unknown":
@@ -160,7 +169,7 @@ class Tei:
         # use restricted as default
         else:
             availability.set("status", "restricted")
-            note = etree.SubElement(availability, "p")
+            note = etree.SubElement(availability, "%sp" % TEI)
             note.text = "Available under licence from the publishers."
 
     def set_encoding_date(self, date):
@@ -168,7 +177,7 @@ class Tei:
         Set the date of encoding for the digital edition
         """
         publication_stmt = self.tree.xpath('//tei:publicationStmt', namespaces=ns)[0]
-        encoding_date = etree.SubElement(publication_stmt, "date")
+        encoding_date = etree.SubElement(publication_stmt, "%sdate" % TEI)
         encoding_date.set("type", "publication")
         encoding_date.text = date
 
@@ -177,7 +186,7 @@ class Tei:
         Sets some details on the encoding of the digital edition
         """
         encoding_desc = self.tree.xpath('//tei:encodingDesc', namespaces=ns)[0]
-        encoding_desc_details = etree.SubElement(encoding_desc, "p")
+        encoding_desc_details = etree.SubElement(encoding_desc, "%sp" % TEI)
         encoding_desc_details.text = "Encoded with the help of %s." % creator
 
     def add_repository(self, repository):
@@ -185,7 +194,7 @@ class Tei:
         Adds the repository of the (original) manuscript
         """
         ms_ident = self.tree.xpath('//tei:msDesc/tei:msIdentifier', namespaces=ns)[0]
-        repository_node = etree.SubElement(ms_ident, "repository")
+        repository_node = etree.SubElement(ms_ident, "%srepository" % TEI)
         repository_node.text = repository
 
     def add_shelfmark(self, shelfmark):
@@ -193,7 +202,7 @@ class Tei:
         Adds the shelf mark of the (original) manuscript
         """
         ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
-        idno = etree.SubElement(ms_ident_idno, "idno")
+        idno = etree.SubElement(ms_ident_idno, "%sidno" % TEI)
         idno.set("type", "shelfmark")
         idno.text = shelfmark
 
@@ -203,7 +212,7 @@ class Tei:
         """
         ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
         for identifier in identifiers:
-            idno = etree.SubElement(ms_ident_idno, "idno")
+            idno = etree.SubElement(ms_ident_idno, "%sidno" % TEI)
             idno.set("type", identifier[0])
             idno.text = identifier[1]
 
@@ -212,9 +221,9 @@ class Tei:
         Sets the type description
         """
         phys_desc = self.tree.xpath('//tei:msDesc/tei:physDesc', namespaces=ns)[0]
-        type_desc = etree.SubElement(phys_desc, "typeDesc")
+        type_desc = etree.SubElement(phys_desc, "%stypeDesc" % TEI)
         for line in description.split('\n'):
-            par = etree.SubElement(type_desc, "p")
+            par = etree.SubElement(type_desc, "%sp" % TEI)
             par.text = line
 
     def add_language(self, language):
@@ -222,7 +231,7 @@ class Tei:
         Add a language of the source document
         """
         lang_usage = self.tree.xpath('//tei:profileDesc/tei:langUsage', namespaces=ns)[0]
-        lang = etree.SubElement(lang_usage, "language")
+        lang = etree.SubElement(lang_usage, "%slanguage" % TEI)
         lang.set("ident", language[0])
         lang.text = language[1]
 
@@ -232,9 +241,9 @@ class Tei:
         """
         phys_desc = self.tree.xpath('//tei:msDesc/tei:physDesc', namespaces=ns)[0]
         if phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns) == []:
-            obj_desc = etree.SubElement(phys_desc, "objectDesc")
-            support_desc = etree.SubElement(obj_desc, "supportDesc")
+            obj_desc = etree.SubElement(phys_desc, "%sobjectDesc" % TEI)
+            support_desc = etree.SubElement(obj_desc, "%ssupportDesc" % TEI)
         else:
             support_desc = phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns)[0]
-        extent_elem = etree.SubElement(support_desc, "extent")
+        extent_elem = etree.SubElement(support_desc, "%sextent" % TEI)
         extent_elem.text = extent

--- a/mets_mods2teiHeader/api/tei.py
+++ b/mets_mods2teiHeader/api/tei.py
@@ -240,10 +240,10 @@ class Tei:
         Add information on the extent of the source document
         """
         phys_desc = self.tree.xpath('//tei:msDesc/tei:physDesc', namespaces=ns)[0]
-        if phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns) == []:
+        if not phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns):
             obj_desc = etree.SubElement(phys_desc, "%sobjectDesc" % TEI)
             support_desc = etree.SubElement(obj_desc, "%ssupportDesc" % TEI)
         else:
             support_desc = phys_desc.xpath('/tei:objectDesc/tei:supportDesc', namespaces=ns)[0]
-        extent_elem = etree.SubElement(support_desc, "%sextent" % TEI)
+        extent_elem = etree.SubElement(support_desc, "{%s}extent" % TEI)
         extent_elem.text = extent

--- a/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
+++ b/mets_mods2teiHeader/scripts/mets_mods2teiHeader.py
@@ -97,6 +97,10 @@ def cli(mets):
     for ident_name in mets.get_languages().items():
         tei.add_language(ident_name)
 
+    # extents
+    for extent in mets.extents:
+        tei.add_extent(extent)
+
     click.echo(tei.tostring())
 
 

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -71,3 +71,6 @@ def test_data_assignment(subtests, datadir):
 
     with subtests.test("Check manuscript edition"):
         assert(mets.get_edition() == '3. Aufl.')
+
+    with subtests.test("Check manuscript extent"):
+        assert(mets.extents == ['[8] Bl., 783 S., [1] Bl.'])

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from mets_mods2teiHeader import Tei
+
+def test_constructor():
+    '''
+    Test the creation of an empty Tei instance
+    '''
+    tei = Tei()
+    assert(tei.tree is not None)
+
+def test_data_assignment(subtests):
+    '''
+    Test the correct assignment of meta data
+    '''
+    tei = Tei()
+
+    with subtests.test("Check main title"):
+        tei.set_main_title("Testbuch")
+        assert(tei.get_main_title() == "Testbuch")

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -17,4 +17,9 @@ def test_data_assignment(subtests):
 
     with subtests.test("Check main title"):
         tei.set_main_title("Testbuch")
-        assert(tei.get_main_title() == "Testbuch")
+        assert(tei.main_title == "Testbuch")
+
+    with subtests.test("Check extent(s)"):
+        tei.add_extent("32 S.")
+        tei.add_extent("5 Abb.")
+        assert(tei.extents == ["32 S.", "5 Abb."])


### PR DESCRIPTION
It is taken from `mods:physicalDescription/mods:extent` and
added to the TEI's manuscript description. In addition, the
first test for the TEI side of things has been added.